### PR TITLE
Make better use of memory by increasing the batch size while adjusting LR

### DIFF
--- a/bin/horovod-single-node-job.sh
+++ b/bin/horovod-single-node-job.sh
@@ -36,6 +36,12 @@ NVIDIA_SMI_DELAY_SECONDS=60
 nvidia-smi dmon --delay $NVIDIA_SMI_DELAY_SECONDS --options DT >> $PERSISTENT_LOGGING_DIR/nvidia-smi.log &
 NVIDIA_SMI_PID=$!
 
+# Start the nvdashboard server running in the background
+NVDASHBOARD_PORT=8889
+python -m jupyterlab_nvdashboard.server $NVDASHBOARD_PORT &
+NVDASHBOARD_PID=$!
+
+https://github.com/kaust-vislab/tensorflow-gpu-data-science-project
 # start the training process in the background
 horovodrun -np $SLURM_NTASKS python $TRAINING_SCRIPT \
     --data-dir $DATA_DIR \
@@ -56,9 +62,9 @@ while [ "${HOROVODRUN_STATE}" != "" ]
         HOROVODRUN_STATE=$(ps -h --pid $HOROVODRUN_PID -o state | head -n 1)
 done
 
-# kill off the nvidia-smi process
+# kill off the GPU monitoring processes
 kill $NVIDIA_SMI_PID
-
+kill $NVDASHBOARD_PID
 # make sure to get any new files written since last rsync 
 rsync -a $LOCAL_CHECKPOINTS_DIR/ $PERSISTENT_CHECKPOINTS_DIR
 rsync -a $LOCAL_TENSORBOARD_DIR/ $PERSISTENT_TENSORBOARD_DIR

--- a/bin/horovod-single-node-job.sh
+++ b/bin/horovod-single-node-job.sh
@@ -41,7 +41,8 @@ horovodrun -np $SLURM_NTASKS python $TRAINING_SCRIPT \
     --data-dir $DATA_DIR \
     --read-checkpoints-from $PERSISTENT_CHECKPOINTS_DIR \
     --write-checkpoints-to  $LOCAL_CHECKPOINTS_DIR \
-    --tensorboard-logging-dir $LOCAL_TENSORBOARD_DIR &
+    --tensorboard-logging-dir $LOCAL_TENSORBOARD_DIR \
+    --batch-size=256 &
 HOROVODRUN_PID=$!
 
 # asynchronous rsync of training logs between local and persistent storage

--- a/bin/horovod-single-node-job.sh
+++ b/bin/horovod-single-node-job.sh
@@ -47,8 +47,7 @@ horovodrun -np $SLURM_NTASKS python $TRAINING_SCRIPT \
     --data-dir $DATA_DIR \
     --read-checkpoints-from $PERSISTENT_CHECKPOINTS_DIR \
     --write-checkpoints-to  $LOCAL_CHECKPOINTS_DIR \
-    --tensorboard-logging-dir $LOCAL_TENSORBOARD_DIR \
-    --batch-size=256 &
+    --tensorboard-logging-dir $LOCAL_TENSORBOARD_DIR &
 HOROVODRUN_PID=$!
 
 # asynchronous rsync of training logs between local and persistent storage

--- a/src/horovod-keras-example/train.py
+++ b/src/horovod-keras-example/train.py
@@ -169,8 +169,9 @@ intial_epoch = hvd.broadcast(initial_epoch, root_rank=0, name='initial_epoch')
 _loss_fn = (keras.losses
                  .CategoricalCrossentropy())
     
-# adjust initial learning rate based on number of GPUs.
-_initial_lr = args.base_lr * hvd.size() 
+# adjust initial learning rate based on number of "effective GPUs".
+_n_effective_gpus = (args.batch_size // 32) * hvd.size() 
+_initial_lr = args.base_lr * _n_effective_gpus 
 _optimizer = (keras.optimizers
                    .SGD(lr=_initial_lr, momentum=args.momentum))
 _distributed_optimizer = hvd.DistributedOptimizer(_optimizer)

--- a/src/horovod-keras-example/train.py
+++ b/src/horovod-keras-example/train.py
@@ -29,11 +29,15 @@ parser.add_argument("--tensorboard-logging-dir",
                     type=str,
                     help="Path to the tensorboard logging directory")
 
-# Default settings from https://arxiv.org/abs/1706.02677.
+# Most default settings from https://arxiv.org/abs/1706.02677.
 parser.add_argument("--batch-size",
                     type=int,
-                    default=32,
+                    default=256,
                     help="input batch size for training")
+parser.add_argument("--base-batch-size",
+                    type=int,
+                    default=32,
+                    help="batch size used to determine number of effective GPUs")
 parser.add_argument("--val-batch-size",
                     type=int,
                     default=32,
@@ -171,7 +175,7 @@ _loss_fn = (keras.losses
     
 # adjust initial learning rate based on number of "effective GPUs".
 _global_batch_size = args.batch_size * hvd.size()
-_n_effective_gpus = _global_batch_size // 32 
+_n_effective_gpus = _global_batch_size // args.base_batch_size 
 _initial_lr = args.base_lr * _n_effective_gpus 
 _optimizer = (keras.optimizers
                    .SGD(lr=_initial_lr, momentum=args.momentum))

--- a/src/horovod-keras-example/train.py
+++ b/src/horovod-keras-example/train.py
@@ -170,7 +170,8 @@ _loss_fn = (keras.losses
                  .CategoricalCrossentropy())
     
 # adjust initial learning rate based on number of "effective GPUs".
-_n_effective_gpus = (args.batch_size // 32) * hvd.size() 
+_global_batch_size = args.batch_size * hvd.size()
+_n_effective_gpus = _global_batch_size // 32 
 _initial_lr = args.base_lr * _n_effective_gpus 
 _optimizer = (keras.optimizers
                    .SGD(lr=_initial_lr, momentum=args.momentum))


### PR DESCRIPTION
Default batch size of 32 can be increased by a factor of 8 to make better use of GPU memory on the node. However in order to maintain convergence of optimizer we need to adjust the initial learning rate accordingly.

To do this I multiply the base LR by the number of "effective GPUs" which is the number of GPUs that it would take with a batch size of 32 to obtain the same global batch size that we get with 8 GPUS and batch size of 256.